### PR TITLE
Harvester tooltip updates

### DIFF
--- a/Regolith/Regolith/Planetary/REGO_ModuleResourceHarvester.cs
+++ b/Regolith/Regolith/Planetary/REGO_ModuleResourceHarvester.cs
@@ -148,7 +148,7 @@ namespace Regolith.Common
                 //Harvesting thresholds, if used.
                 if (abundance < HarvestThreshold || abundance < Utilities.FLOAT_TOLERANCE)
                 {
-                    status = "nothing to harvest";
+                    status = "resource below threshold";
                     IsActivated = false;
                     return null;
                 }

--- a/Regolith/Regolith/Planetary/REGO_ModuleResourceHarvester.cs
+++ b/Regolith/Regolith/Planetary/REGO_ModuleResourceHarvester.cs
@@ -47,7 +47,7 @@ namespace Regolith.Common
         public override string GetInfo()
         {
             var sb = new StringBuilder();
-            var recipe = LoadRecipe(1);
+            var recipe = LoadRecipe(Efficiency);
             sb.Append(".");
             sb.Append("\n");
             sb.Append(ConverterName);


### PR DESCRIPTION
The status should show that threshold is preventing extraction instead of lack of resources.

Also the tooltip for all harvesters was showing efficiency of 1 instead of the actual efficiency.