### PR TITLE
Clamp coordinates to -180W to 180E and -90S to 90N

### DIFF
--- a/Regolith/Regolith/Common/Utilities.cs
+++ b/Regolith/Regolith/Common/Utilities.cs
@@ -147,6 +147,15 @@ namespace Regolith.Common
             }
         }
 
+		public static double fixLat(double lat)
+		{
+			return (lat + 180 + 90) % 180 - 90;
+		}
+
+		public static double fixLong(double lon)
+		{
+			return (lon + 360 + 180) % 360 - 180;
+		}
 
         public static double Deg2Rad(double degrees)
         {

--- a/Regolith/Regolith/Planetary/REGO_ModuleBiomeScanner.cs
+++ b/Regolith/Regolith/Planetary/REGO_ModuleBiomeScanner.cs
@@ -13,8 +13,8 @@ namespace Regolith.Common
         void RunAnalysis()
         {
             var thisBody = vessel.mainBody;
-            var thisLat = Utilities.Deg2Rad(vessel.latitude);
-            var thisLon = Utilities.Deg2Rad(vessel.longitude);
+            var thisLat = Utilities.Deg2Rad(Utilities.fixLat(vessel.latitude));
+            var thisLon = Utilities.Deg2Rad(Utilities.fixLong(vessel.longitude));
             var biome = Utilities.GetBiome(thisLat, thisLon, FlightGlobals.currentMainBody);
             var biomeName = vessel.situation.ToString();
             if (biome != null)
@@ -40,8 +40,8 @@ namespace Regolith.Common
             if (isEnabled)
             {
                 var thisBody = vessel.mainBody;
-                var thisLat = Utilities.Deg2Rad(vessel.latitude);
-                var thisLon = Utilities.Deg2Rad(vessel.longitude);
+                var thisLat = Utilities.Deg2Rad(Utilities.fixLat(vessel.latitude));
+                var thisLon = Utilities.Deg2Rad(Utilities.fixLong(vessel.longitude));
                 var biome = Utilities.GetBiome(thisLat, thisLon, FlightGlobals.currentMainBody);
                 var biomeName = vessel.situation.ToString();
                 if (biome != null)

--- a/Regolith/Regolith/Planetary/REGO_ModuleGPS.cs
+++ b/Regolith/Regolith/Planetary/REGO_ModuleGPS.cs
@@ -18,13 +18,13 @@ namespace Regolith.Common
             try
             {
                 var thisBody = FlightGlobals.currentMainBody;
-                var thisLat = Utilities.Deg2Rad(vessel.latitude);
-                var thisLon = Utilities.Deg2Rad(vessel.longitude);
+                var thisLat = Utilities.Deg2Rad(Utilities.fixLat(vessel.latitude));
+                var thisLon = Utilities.Deg2Rad(Utilities.fixLong(vessel.longitude));
                 var biome = Utilities.GetBiome(thisLat, thisLon, FlightGlobals.currentMainBody);
 
                 body = thisBody.bodyName;
-                lat = String.Format("{0:0.000} [{1:0.000}N]", vessel.latitude, thisLat);
-                lon = String.Format("{0:0.000} [{1:0.000}E]", vessel.longitude, thisLon);
+                lat = String.Format("{0:0.000} [{1:0.000}N]", Utilities.fixLat(vessel.latitude), thisLat);
+                lon = String.Format("{0:0.000} [{1:0.000}E]", Utilities.fixLong(vessel.longitude), thisLon);
                 if (biome != null)
                 {
                     bioName = biome.name;

--- a/Regolith/Regolith/Planetary/RegolithResourceMap.cs
+++ b/Regolith/Regolith/Planetary/RegolithResourceMap.cs
@@ -108,8 +108,8 @@ namespace Regolith.Common
         {
             try
             {
-                var northing = Utilities.Deg2Rad(request.Latitude);
-                var easting = Utilities.Deg2Rad(request.Longitude);
+                var northing = Utilities.Deg2Rad(Utilities.fixLat(request.Latitude));
+                var easting = Utilities.Deg2Rad(Utilities.fixLong(request.Longitude));
                 var body = FlightGlobals.Bodies.FirstOrDefault(b => b.flightGlobalsIndex == request.BodyId);
                 var biome = Utilities.GetBiome(northing, easting, body);
                 var seed = GenerateAbundanceSeed(request, biome, body);


### PR DESCRIPTION
KSP doesn't always give coordinates that make sense, this seems to be causing a mismatch between resource values given by SCANsat vs those given by Regolith. Clamping the coordinates fixes this and also makes the GPS values make more sense.