### PR TITLE
Balance mining with HarvestThreshold

### DIFF
--- a/Regolith/Regolith/Planetary/REGO_ModuleResourceHarvester.cs
+++ b/Regolith/Regolith/Planetary/REGO_ModuleResourceHarvester.cs
@@ -166,7 +166,7 @@ namespace Regolith.Common
                     return null;
                 }
 
-                var rate = abundance * Efficiency;
+                var rate = Math.Max(abundance - HarvestThreshold, 0) * Efficiency;
                 if (HarvesterType == 2) //Account for altitude and airspeed
                 {
                     double atmDensity = vessel.atmDensity;


### PR DESCRIPTION
Allows larger more efficient drills better balance with smaller drills esp at low concentrations near HarvestThreshold. Currently small radial karbonite drill is 17.5x more mass efficient than the large.